### PR TITLE
optimizations and detect processor type

### DIFF
--- a/freewili/cli.py
+++ b/freewili/cli.py
@@ -132,7 +132,7 @@ def main() -> None:
     if args.get_file:
         match get_device(device_index):
             case Ok(device):
-                data = device.get_file(args.upload_file[0]).unwrap()
+                data = device.get_file(args.get_file[0]).unwrap()
                 with open(args.get_file[1], "w+b") as f:
                     f.write(data)
             case Err(msg):


### PR DESCRIPTION
- Send file is faster.
- fixed get_file parameter
- added the following:
  - `reset_to_uf2_bootloader`
  - `_wait_for_serial_data`
  - `detect_processor_type`
  - `FreeWiliProcessorType`
  - `needs_open` decorator can now toggle menu on or off
  - `fwi-serial -l` now includes if its the Main or Display processor. If we can't  open the port its displayed as Unknown.